### PR TITLE
Bugfix/concurrency conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a RESTful API for sales management, designed with Clean Architecture pri
 
 ---
 
-## 🚀 Tecnologias e Padrões Utilizados
+## 🚀 Technologies and Standards Used
 
 - **.NET 8**
 - **PostgreSQL** as the relational database
@@ -125,7 +125,7 @@ The following domain events are published and logged:
 ## 👨‍💻 Author
 
 **Aurílio Mendes**  
-Senior .NET Developer | Aspiring Software Architect
+Senior .NET Developer | Aspiring Software Architect   
 LinkedIn: [@aurilio](https://www.linkedin.com/in/auriliomendes/)
 
 

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleHandler.cs
@@ -5,8 +5,6 @@ using Ambev.DeveloperEvaluation.Messaging.Interfaces;
 using AutoMapper;
 using MediatR;
 using Microsoft.Extensions.Logging;
-using Microsoft.VisualBasic;
-using System.Security.Cryptography;
 
 namespace Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
 
@@ -48,12 +46,15 @@ public class CreateSaleHandler : IRequestHandler<CreateSaleCommand, CreateSaleRe
     {
         _logger.LogInformation("Handling CreateSaleCommand for SaleNumber: {SaleNumber}", command.SaleNumber);
 
+        if (command.Items == null || command.Items.Count() <= 0)
+            throw new DomainException("A sale must have at least one item.");
+
         var saleItems = MapSaleItems(command);
         var sale = BuildSale(command, saleItems);
-        
+
         foreach (var item in command.Items)
         {
-            var saleItem = new SaleItem(item.ProductId, item.Quantity, item.ProductDetails);
+            var saleItem = new SaleItem(Guid.Empty, Guid.Empty, item.ProductId, item.Quantity, item.ProductDetails);
             sale.AddItem(saleItem);
         }
 
@@ -73,7 +74,7 @@ public class CreateSaleHandler : IRequestHandler<CreateSaleCommand, CreateSaleRe
     private static List<SaleItem> MapSaleItems(CreateSaleCommand command)
     {
         return command.Items
-            .Select(item => new SaleItem(item.ProductId, item.Quantity, item.ProductDetails))
+            .Select(item => new SaleItem(Guid.Empty, Guid.Empty, item.ProductId, item.Quantity, item.ProductDetails))
             .ToList();
     }
 

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleHandler.cs
@@ -5,6 +5,8 @@ using Ambev.DeveloperEvaluation.Messaging.Interfaces;
 using AutoMapper;
 using MediatR;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualBasic;
+using System.Security.Cryptography;
 
 namespace Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
 
@@ -48,6 +50,12 @@ public class CreateSaleHandler : IRequestHandler<CreateSaleCommand, CreateSaleRe
 
         var saleItems = MapSaleItems(command);
         var sale = BuildSale(command, saleItems);
+        
+        foreach (var item in command.Items)
+        {
+            var saleItem = new SaleItem(item.ProductId, item.Quantity, item.ProductDetails);
+            sale.AddItem(saleItem);
+        }
 
         sale.SaleDate = DateTime.SpecifyKind(sale.SaleDate, DateTimeKind.Utc);
 
@@ -76,8 +84,7 @@ public class CreateSaleHandler : IRequestHandler<CreateSaleCommand, CreateSaleRe
             saleDate: command.SaleDate,
             customerId: command.CustomerId,
             customerName: command.CustomerName,
-            branch: command.Branch,
-            items: saleItems
+            branch: command.Branch
         );
     }
 }

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleItemCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleItemCommand.cs
@@ -7,6 +7,9 @@ namespace Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
 /// </summary>
 public class CreateSaleItemCommand
 {
+    public Guid Id { get; set; }
+    public Guid SaleId { get; set; }
+
     /// <summary>
     /// Gets or sets the external identifier of the product.
     /// </summary>

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CreateSale/CreateSaleProfile.cs
@@ -20,6 +20,8 @@ public class CreateSaleProfile : Profile
 
         CreateMap<CreateSaleItemCommand, SaleItem>()
             .ConstructUsing(cmd => new SaleItem(
+                cmd.Id,
+                cmd.SaleId,
                 cmd.ProductId,
                 cmd.Quantity,
                 cmd.ProductDetails

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleItemResult.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleItemResult.cs
@@ -6,6 +6,11 @@
 public class GetSaleItemResult
 {
     /// <summary>
+    /// The unique identifier.
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
     /// The external identifier of the product.
     /// </summary>
     public Guid ProductId { get; set; }

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleProfile.cs
@@ -14,7 +14,9 @@ public class GetSaleProfile : Profile
     /// </summary>
     public GetSaleProfile()
     {
-        CreateMap<Sale, GetSaleResult>();
+        CreateMap<Sale, GetSaleResult>()
+            .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id));
+        
         CreateMap<SaleItem, GetSaleItemResult>();
         CreateMap<ProductDetails, ProductDetailsResult>();
     }

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleResult.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/GetSale/GetSaleResult.cs
@@ -9,6 +9,7 @@ public class GetSaleResult
     /// The unique identifier of the sale record.
     /// </summary>
     public Guid Id { get; set; }
+
     /// <summary>
     /// The number of the sale.
     /// </summary>

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleItemCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/UpdateSale/UpdateSaleItemCommand.cs
@@ -8,6 +8,11 @@ namespace Ambev.DeveloperEvaluation.Application.Sales.UpdateSale;
 public class UpdateSaleItemCommand
 {
     /// <summary>
+    /// The unique identifier.
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
     /// Product identifier.
     /// </summary>
     public Guid ProductId { get; set; }

--- a/src/Ambev.DeveloperEvaluation.Domain/Entities/SaleItem.cs
+++ b/src/Ambev.DeveloperEvaluation.Domain/Entities/SaleItem.cs
@@ -53,6 +53,11 @@ public class SaleItem : BaseEntity
     /// </summary>
     public ProductDetails ProductDetails { get; private set; } = default!;
 
+    private bool _isModified = false;
+    public bool IsModified => _isModified;
+
+    public void MarkAsModified() => _isModified = true;
+
     /// <summary>
     /// Parameterless constructor for EF Core.
     /// </summary>
@@ -81,6 +86,7 @@ public class SaleItem : BaseEntity
     public void Update(Guid productId, int quantity, ProductDetails productDetails)
     {
         UpdatedAt = DateTime.UtcNow;
+        _isModified = true;
         SetValues(productId, quantity, productDetails);
     }
 
@@ -99,10 +105,21 @@ public class SaleItem : BaseEntity
         
         ProductId = productId;
         Quantity = quantity;
-        ProductDetails = productDetails ?? throw new ArgumentNullException(nameof(productDetails));
         Discount = CalculateDiscount(quantity);
         UnitPrice = productDetails.Price * (1 - Discount);
         TotalAmount = Quantity * UnitPrice;
+
+        if(productDetails == null)
+            throw new ArgumentNullException(nameof(productDetails));
+        else
+        {
+            ProductDetails = new ProductDetails(
+                productDetails.Title,
+                productDetails.Category,
+                productDetails.Price,
+                productDetails.Image
+            );
+        }
     }
 
     /// <summary>

--- a/src/Ambev.DeveloperEvaluation.Domain/Entities/SaleItem.cs
+++ b/src/Ambev.DeveloperEvaluation.Domain/Entities/SaleItem.cs
@@ -10,6 +10,9 @@ namespace Ambev.DeveloperEvaluation.Domain.Entities;
 /// </summary>
 public class SaleItem : BaseEntity
 {
+
+    public Guid SaleId { get; private set; }
+
     /// <summary>
     /// Gets the identifier of the product from the product catalog.
     /// </summary>
@@ -53,11 +56,6 @@ public class SaleItem : BaseEntity
     /// </summary>
     public ProductDetails ProductDetails { get; private set; } = default!;
 
-    private bool _isModified = false;
-    public bool IsModified => _isModified;
-
-    public void MarkAsModified() => _isModified = true;
-
     /// <summary>
     /// Parameterless constructor for EF Core.
     /// </summary>
@@ -69,9 +67,10 @@ public class SaleItem : BaseEntity
     /// <param name="productId">The unique identifier of the product being sold.</param>
     /// <param name="quantity">The number of items sold.</param>
     /// <param name="productDetails">The denormalized product details (title, category, price, image).</param>
-    public SaleItem(Guid productId, int quantity, ProductDetails productDetails)
+    public SaleItem(Guid? id, Guid saleId, Guid productId, int quantity, ProductDetails productDetails)
     {
-        Id = Guid.NewGuid();
+        Id = id == null ? Guid.NewGuid() : id.Value;
+        SaleId = saleId;
         CreatedAt = DateTime.UtcNow;
         SetValues(productId, quantity, productDetails);
     }
@@ -86,7 +85,6 @@ public class SaleItem : BaseEntity
     public void Update(Guid productId, int quantity, ProductDetails productDetails)
     {
         UpdatedAt = DateTime.UtcNow;
-        _isModified = true;
         SetValues(productId, quantity, productDetails);
     }
 
@@ -102,24 +100,23 @@ public class SaleItem : BaseEntity
     private void SetValues(Guid productId, int quantity, ProductDetails productDetails)
     {
         ValidateSaleInputs(quantity);
-        
+
         ProductId = productId;
         Quantity = quantity;
-        Discount = CalculateDiscount(quantity);
-        UnitPrice = productDetails.Price * (1 - Discount);
-        TotalAmount = Quantity * UnitPrice;
 
-        if(productDetails == null)
+        if (productDetails == null)
             throw new ArgumentNullException(nameof(productDetails));
-        else
-        {
-            ProductDetails = new ProductDetails(
-                productDetails.Title,
-                productDetails.Category,
-                productDetails.Price,
-                productDetails.Image
-            );
-        }
+
+        ProductDetails = new ProductDetails(
+            productDetails.Title,
+            productDetails.Category,
+            productDetails.Price,
+            productDetails.Image
+        );
+
+        Discount = CalculateDiscount(quantity); // 👈 Primeiro calcula o desconto
+        UnitPrice = ProductDetails.Price * (1 - Discount); // 👈 Agora sim calcula o preço unitário com desconto
+        TotalAmount = Quantity * UnitPrice; // 👈 E por fim o total
     }
 
     /// <summary>

--- a/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
@@ -10,6 +10,8 @@ public class DefaultContext : DbContext
 {
     public DbSet<User> Users { get; set; }
     public DbSet<Sale> Sales { get; set; }
+    public DbSet<SaleItem> SalesItem { get; set; }
+
     public DbSet<Customer> Custumers { get; set; }
     public DbSet<Product> Products { get; set; }
 

--- a/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleConfiguration.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleConfiguration.cs
@@ -50,6 +50,12 @@ public class SaleConfiguration : IEntityTypeConfiguration<Sale>
             .IsRequired()
             .HasColumnType("numeric(18,2)");
 
+        builder.Property(e => e.Version)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .IsConcurrencyToken()
+            .ValueGeneratedOnAddOrUpdate();
+
         builder.HasMany(s => s.Items)
             .WithOne()
             .HasForeignKey("SaleId")

--- a/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleItemConfiguration.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleItemConfiguration.cs
@@ -15,7 +15,7 @@ public class SaleItemConfiguration : IEntityTypeConfiguration<SaleItem>
             .HasColumnType("uuid")
             .HasDefaultValueSql("gen_random_uuid()");
 
-        builder.Property<Guid>("SaleId")
+        builder.Property(si => si.SaleId)
             .IsRequired()
             .HasColumnType("uuid");
 
@@ -61,6 +61,8 @@ public class SaleItemConfiguration : IEntityTypeConfiguration<SaleItem>
             pd.Property(p => p.Image)
               .HasColumnName("ProductImage")
               .IsRequired();
+
+            pd.WithOwner();
         });
     }
 }

--- a/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250423175230_CreateTables.Designer.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250423175230_CreateTables.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Ambev.DeveloperEvaluation.ORM.Migrations
 {
     [DbContext(typeof(DefaultContext))]
-    [Migration("20250418023920_CreateTables")]
+    [Migration("20250423175230_CreateTables")]
     partial class CreateTables
     {
         /// <inheritdoc />
@@ -117,6 +117,12 @@ namespace Ambev.DeveloperEvaluation.ORM.Migrations
 
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("timestamp with time zone");
+
+                    b.Property<uint>("Version")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("xid")
+                        .HasColumnName("xmin");
 
                     b.HasKey("Id");
 

--- a/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250423175230_CreateTables.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250423175230_CreateTables.cs
@@ -11,19 +11,6 @@ namespace Ambev.DeveloperEvaluation.ORM.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<DateTime>(
-                name: "CreatedAt",
-                table: "Users",
-                type: "timestamp with time zone",
-                nullable: false,
-                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
-
-            migrationBuilder.AddColumn<DateTime>(
-                name: "UpdatedAt",
-                table: "Users",
-                type: "timestamp with time zone",
-                nullable: true);
-
             migrationBuilder.CreateTable(
                 name: "Customers",
                 columns: table => new
@@ -67,7 +54,8 @@ namespace Ambev.DeveloperEvaluation.ORM.Migrations
                     Branch = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                     IsCancelled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
                     CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
-                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false)
                 },
                 constraints: table =>
                 {
@@ -123,14 +111,6 @@ namespace Ambev.DeveloperEvaluation.ORM.Migrations
 
             migrationBuilder.DropTable(
                 name: "Sales");
-
-            migrationBuilder.DropColumn(
-                name: "CreatedAt",
-                table: "Users");
-
-            migrationBuilder.DropColumn(
-                name: "UpdatedAt",
-                table: "Users");
         }
     }
 }

--- a/src/Ambev.DeveloperEvaluation.ORM/Migrations/DefaultContextModelSnapshot.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Migrations/DefaultContextModelSnapshot.cs
@@ -115,6 +115,12 @@ namespace Ambev.DeveloperEvaluation.ORM.Migrations
                     b.Property<DateTime?>("UpdatedAt")
                         .HasColumnType("timestamp with time zone");
 
+                    b.Property<uint>("Version")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("xid")
+                        .HasColumnName("xmin");
+
                     b.HasKey("Id");
 
                     b.ToTable("Sales", (string)null);

--- a/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Repositories/SaleRepository.cs
@@ -54,9 +54,10 @@ public class SaleRepository : ISaleRepository
     {
         _logger.LogDebug("Fetching sale with ID: {SaleId}", id);
 
-        var result = await _context.Sales.AsNoTracking()
-                                    .Include(s => s.Items)
-                                    .FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+        var result = await _context.Sales
+                            .Include(s => s.Items)
+                            .AsTracking()
+                            .FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
 
         return result;
     }
@@ -114,9 +115,36 @@ public class SaleRepository : ISaleRepository
     /// <returns>The updated sale.</returns>
     public async Task<Sale?> UpdateAsync(Sale sale, CancellationToken cancellationToken = default)
     {
-        _context.Sales.Update(sale);
-
         _logger.LogDebug("Saving changes to database for sale ID: {SaleId}", sale.Id);
+
+        //foreach (var item in sale.Items)
+        //{
+        //    var entry = _context.Entry(item);
+
+        //    if (entry.State == EntityState.Detached)
+        //    {
+        //        // Obtem o original do banco (importante!)
+        //        var trackedItem = await _context.SalesItem
+        //            .Include(i => i.ProductDetails) // importante se for owned
+        //            .FirstOrDefaultAsync(i => i.Id == item.Id, cancellationToken);
+
+        //        if (trackedItem != null)
+        //        {
+        //            _context.Entry(trackedItem).CurrentValues.SetValues(item);
+        //            _context.Entry(trackedItem).State = EntityState.Modified;
+        //        }
+        //        else
+        //        {
+        //            _context.SalesItem.Attach(item);
+        //            entry.State = EntityState.Added;
+        //        }
+        //    }
+        //    else if (item.IsModified)
+        //    {
+        //        entry.State = EntityState.Modified;
+        //    }
+        //}
+
         await _context.SaveChangesAsync(cancellationToken);
 
         _logger.LogInformation("Sale with ID {SaleId} updated successfully.", sale.Id);

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CreateSale/SaleItemResponse.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/CreateSale/SaleItemResponse.cs
@@ -6,6 +6,11 @@
 public class SaleItemResponse
 {
     /// <summary>
+    /// The unique identifier.
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
     /// Gets or sets the external product identifier.
     /// </summary>
     public Guid ProductId { get; set; }

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/UpdateSale/UpdateSaleItemRequest.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/UpdateSale/UpdateSaleItemRequest.cs
@@ -8,6 +8,14 @@ namespace Ambev.DeveloperEvaluation.WebApi.Features.Sales.UpdateSale;
 /// </summary>
 public class UpdateSaleItemRequest
 {
+    /// <summary>
+    /// The unique identifier.
+    /// </summary>
+    public Guid? Id { get; set; }
+
+    /// <summary>
+    /// Product identifier.
+    /// </summary>
     [Required]
     public Guid ProductId { get; set; }
 

--- a/src/Ambev.DeveloperEvaluation.WebApi/Program.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Program.cs
@@ -1,4 +1,4 @@
-using Ambev.DeveloperEvaluation.Application;
+Ôªøusing Ambev.DeveloperEvaluation.Application;
 using Ambev.DeveloperEvaluation.Common.HealthChecks;
 using Ambev.DeveloperEvaluation.Common.Logging;
 using Ambev.DeveloperEvaluation.Common.Security;
@@ -116,16 +116,16 @@ public class Program
 
                 retryPolicy.Execute(() =>
                 {
-                    Log.Information("Testando conex„o com o banco...");
+                    Log.Information("Testando conex√£o com o banco...");
                     try
                     {
                         connection.Open();
                         connection.Close();
-                        Log.Information("Conex„o com o banco bem-sucedida!");
+                        Log.Information("Conex√£o com o banco bem-sucedida!");
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "Erro ao testar a conex„o com o banco.");
+                        Log.Error(ex, "Erro ao testar a conex√£o com o banco.");
                         throw;
                     }
 

--- a/src/Ambev.DeveloperEvaluation.WebApi/appsettings.json
+++ b/src/Ambev.DeveloperEvaluation.WebApi/appsettings.json
@@ -1,7 +1,8 @@
 {
   "ConnectionStrings": {
-    //"DefaultConnection": "Server=ambev.developerevaluation.database;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True"
-    "DefaultConnection": "Server=localhost;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True"
+    "DefaultConnection": "Server=ambev.developerevaluation.database;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True"
+    //"DefaultConnection": "Server=localhost;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True",
+    //"DefaultConnection": "Server=localhost;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True;Include Error Detail=true"
   },
   "Jwt": {
     "SecretKey": "YourSuperSecretKeyForJwtTokenGenerationThatShouldBeAtLeast32BytesLong"

--- a/src/Ambev.DeveloperEvaluation.WebApi/appsettings.json
+++ b/src/Ambev.DeveloperEvaluation.WebApi/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=ambev.developerevaluation.database;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True"
-    //"DefaultConnection": "Server=localhost;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True"
+    //"DefaultConnection": "Server=ambev.developerevaluation.database;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True"
+    "DefaultConnection": "Server=localhost;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True"
   },
   "Jwt": {
     "SecretKey": "YourSuperSecretKeyForJwtTokenGenerationThatShouldBeAtLeast32BytesLong"

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/CreateUserHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/CreateUserHandlerTests.cs
@@ -80,7 +80,7 @@ public class CreateUserHandlerTests
     public async Task Handle_InvalidRequest_ThrowsValidationException()
     {
         // Given
-        var command = new CreateUserCommand(); // Empty command will fail validation
+        var command = new CreateUserCommand();
 
         // When
         var act = () => _handler.Handle(command, CancellationToken.None);

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/CreateSaleHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/CreateSaleHandlerTests.cs
@@ -1,18 +1,14 @@
 ﻿using Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
 using Ambev.DeveloperEvaluation.Domain.Entities;
 using Ambev.DeveloperEvaluation.Domain.Repositories;
-using Ambev.DeveloperEvaluation.Messaging.Common;
 using Ambev.DeveloperEvaluation.Messaging.Events;
 using Ambev.DeveloperEvaluation.Messaging.Interfaces;
-using Ambev.DeveloperEvaluation.ORM.Repositories;
 using Ambev.DeveloperEvaluation.Unit.Application.SaleTest.TestData;
 using AutoMapper;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
-using Serilog.Core;
-using System.ComponentModel.DataAnnotations;
 using Xunit;
 
 namespace Ambev.DeveloperEvaluation.Unit.Application.SaleTest;
@@ -38,8 +34,7 @@ public class CreateSaleHandlerTests
     {
         // Arrange
         var command = CreateSaleHandlerTestData.GenerateValidCommand();
-        var sale = new Sale(command.SaleNumber, command.SaleDate, command.CustomerId, command.CustomerName, command.Branch,
-            command.Items.Select(i => new SaleItem(i.ProductId, i.Quantity, i.ProductDetails)));
+        var sale = new Sale(command.SaleNumber, command.SaleDate, command.CustomerId, command.CustomerName, command.Branch);
 
         _saleRepository.CreateAsync(Arg.Any<Sale>(), Arg.Any<CancellationToken>()).Returns(sale);
 
@@ -73,7 +68,6 @@ public class CreateSaleHandlerTests
     {
         // Arrange
         var command = CreateSaleHandlerTestData.GenerateValidCommand();
-        //var handler = CreateHandler(out var repository, out var mapper, out var logger, out var publisher);
 
         var mappedResult = new CreateSaleResult { Id = Guid.NewGuid() };
         _mapper.Map<CreateSaleResult>(Arg.Any<Sale>()).Returns(mappedResult);
@@ -98,8 +92,7 @@ public class CreateSaleHandlerTests
     {
         // Arrange
         var command = CreateSaleHandlerTestData.GenerateValidCommand();
-        var sale = new Sale(command.SaleNumber, command.SaleDate, command.CustomerId, command.CustomerName, command.Branch,
-            command.Items.Select(i => new SaleItem(i.ProductId, i.Quantity, i.ProductDetails)).ToList());
+        var sale = new Sale(command.SaleNumber, command.SaleDate, command.CustomerId, command.CustomerName, command.Branch);
 
         var result = new CreateSaleResult { Id = sale.Id };
 
@@ -121,8 +114,7 @@ public class CreateSaleHandlerTests
 
         // Arrange
         var command = CreateSaleHandlerTestData.GenerateValidCommand();
-        var sale = new Sale(command.SaleNumber, command.SaleDate, command.CustomerId, command.CustomerName, command.Branch,
-            command.Items.Select(i => new SaleItem(i.ProductId, i.Quantity, i.ProductDetails)).ToList());
+        var sale = new Sale(command.SaleNumber, command.SaleDate, command.CustomerId, command.CustomerName, command.Branch);
 
         _saleRepository.CreateAsync(Arg.Any<Sale>(), Arg.Any<CancellationToken>()).Returns(sale);
         _mapper.Map<CreateSaleResult>(sale).Returns(new CreateSaleResult { Id = sale.Id });
@@ -140,13 +132,13 @@ public class CreateSaleHandlerTests
     public async Task Handle_InvalidCommand_ThrowsValidationException()
     {
         // Arrange
-        var invalidCommand = new CreateSaleCommand(); // Faltam campos obrigatórios
+        var invalidCommand = new CreateSaleCommand();
 
         // Act
         var act = () => _handler.Handle(invalidCommand, CancellationToken.None);
 
         // Assert
-        await act.Should().ThrowAsync<ArgumentException>();
+        await act.Should().ThrowAsync<DomainException>();
     }
 
     [Fact(DisplayName = "Given repository throws exception When handling Then propagates exception")]
@@ -179,8 +171,7 @@ public class CreateSaleHandlerTests
             command.SaleDate,
             command.CustomerId,
             command.CustomerName,
-            command.Branch,
-            command.Items.Select(i => new SaleItem(i.ProductId, i.Quantity, i.ProductDetails)).ToList()
+            command.Branch
         );
 
         _saleRepository.CreateAsync(

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/GetSaleHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/GetSaleHandlerTests.cs
@@ -2,7 +2,6 @@
 using Ambev.DeveloperEvaluation.Common.Exceptions;
 using Ambev.DeveloperEvaluation.Domain.Entities;
 using Ambev.DeveloperEvaluation.Domain.Repositories;
-using Ambev.DeveloperEvaluation.Domain.ValueObjects;
 using AutoMapper;
 using Bogus;
 using FluentAssertions;
@@ -41,16 +40,7 @@ public class GetSaleHandlerTests
             _faker.Date.Past(),
             Guid.NewGuid(),
             _faker.Name.FullName(),
-            _faker.Company.CompanyName(),
-            new List<SaleItem>
-            {
-            new SaleItem(Guid.NewGuid(), 10,
-                new ProductDetails(
-                    _faker.Commerce.ProductName(),
-                    _faker.Commerce.Categories(1)[0],
-                    _faker.Random.Decimal(100, 1000),
-                    _faker.Image.PicsumUrl()))
-            }
+            _faker.Company.CompanyName()
         );
 
         var expectedResult = new GetSaleResult { Id = sale.Id };

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/ListSaleHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/ListSaleHandlerTests.cs
@@ -2,15 +2,12 @@
 using Ambev.DeveloperEvaluation.Common.Pagination;
 using Ambev.DeveloperEvaluation.Domain.Entities;
 using Ambev.DeveloperEvaluation.Domain.Repositories;
-using Ambev.DeveloperEvaluation.Domain.ValueObjects;
 using AutoMapper;
 using Bogus;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
-using MockQueryable.NSubstitute;
 using Xunit;
-using MockQueryable;
 
 namespace Ambev.DeveloperEvaluation.Unit.Application.SaleTest;
 
@@ -41,16 +38,7 @@ public class ListSaleHandlerTests
             _faker.Date.Recent(),
             Guid.NewGuid(),
             _faker.Name.FullName(),
-            _faker.Company.CompanyName(),
-            new List<SaleItem>
-            {
-            new SaleItem(Guid.NewGuid(), 10,
-                new ProductDetails(
-                    _faker.Commerce.ProductName(),
-                    _faker.Commerce.Categories(1)[0],
-                    _faker.Random.Decimal(10, 100),
-                    _faker.Image.PicsumUrl()))
-            }
+            _faker.Company.CompanyName()
         )).ToList();
 
         var paginated = new PaginatedList<Sale>(
@@ -94,12 +82,8 @@ public class ListSaleHandlerTests
             saleDate: _faker.Date.Recent(),
             customerId: Guid.NewGuid(),
             customerName: _faker.Name.FullName(),
-            branch: "Filial São Paulo",
-            items: new List<SaleItem>
-            {
-            new SaleItem(Guid.NewGuid(), 4,
-                new ProductDetails("Produto", "Categoria", 100m, "img.png"))
-            });
+            branch: "Filial São Paulo"
+        );
 
         var paginated = new PaginatedList<Sale>(
             items: new List<Sale> { matchingSale },
@@ -138,12 +122,7 @@ public class ListSaleHandlerTests
             _faker.Date.Past(),
             Guid.NewGuid(),
             _faker.Name.FullName(),
-            _faker.Company.CompanyName(),
-            new List<SaleItem>
-            {
-            new SaleItem(Guid.NewGuid(), 3,
-                new ProductDetails("Test", "Cat", 50m, "img.png"))
-            }
+            _faker.Company.CompanyName()
         )).ToList();
 
         var paginated = new PaginatedList<Sale>(

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/SaleItemTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/SaleItemTests.cs
@@ -29,7 +29,7 @@ public class SaleItemTests
         var product = FakeProductDetails(price);
 
         // Act
-        var item = new SaleItem(Guid.NewGuid(), quantity, product);
+        var item = new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), quantity, product);
 
         // Assert
         item.Discount.Should().Be(expectedDiscount);
@@ -43,7 +43,7 @@ public class SaleItemTests
     {
         var product = FakeProductDetails(price);
 
-        var item = new SaleItem(Guid.NewGuid(), quantity, product);
+        var item = new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), quantity, product);
 
         item.UnitPrice.Should().Be(expectedUnitPrice);
     }
@@ -56,7 +56,7 @@ public class SaleItemTests
     {
         var product = FakeProductDetails(price);
 
-        var item = new SaleItem(Guid.NewGuid(), quantity, product);
+        var item = new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), quantity, product);
 
         item.TotalAmount.Should().Be(expectedTotal);
     }
@@ -66,7 +66,7 @@ public class SaleItemTests
     {
         var product = FakeProductDetails(100);
 
-        Action act = () => new SaleItem(Guid.NewGuid(), 21, product);
+        Action act = () => new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 21, product);
 
         act.Should().Throw<DomainException>()
             .WithMessage("Cannot sell more than 20 identical items.");
@@ -77,7 +77,7 @@ public class SaleItemTests
     {
         var product = FakeProductDetails(100);
 
-        Action act = () => new SaleItem(Guid.NewGuid(), 0, product);
+        Action act = () => new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 0, product);
 
         act.Should().Throw<DomainException>()
             .WithMessage("Quantity must be greater than zero.");
@@ -87,7 +87,7 @@ public class SaleItemTests
     public void SaleItem_ShouldThrowException_WhenProductDetailsIsNull()
     {
         var product = FakeProductDetails(100);
-        Action act = () => new SaleItem(Guid.NewGuid(), 0, product);
+        Action act = () => new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 0, product);
 
         act.Should().Throw<DomainException>()
             .WithMessage("Quantity must be greater than zero.");

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/TestData/CreateSaleHandlerTestData.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/TestData/CreateSaleHandlerTestData.cs
@@ -1,5 +1,4 @@
 ﻿using Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
-using Ambev.DeveloperEvaluation.Domain.Entities;
 using Ambev.DeveloperEvaluation.Domain.ValueObjects;
 using Bogus;
 

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/TestData/UpdateSaleTestData.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/TestData/UpdateSaleTestData.cs
@@ -44,11 +44,7 @@ public static class UpdateSaleTestData
             _faker.Date.Recent(),
             Guid.NewGuid(),
             _faker.Name.FullName(),
-            _faker.Company.CompanyName(),
-            new List<SaleItem>
-            {
-            new SaleItem(Guid.NewGuid(), 1, new ProductDetails("Original", "Cat", 50m, "img"))
-            }
+            _faker.Company.CompanyName()
         );
     }
 }

--- a/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/UpdateSaleHandlerTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Application/SaleTest/UpdateSaleHandlerTests.cs
@@ -43,7 +43,7 @@ public class UpdateSaleHandlerTests
         _saleRepository.GetByIdAsync(command.Id, Arg.Any<CancellationToken>()).Returns(sale);
         _saleRepository.UpdateAsync(sale, Arg.Any<CancellationToken>()).Returns(sale);
         _mapper.Map<SaleItem>(Arg.Any<UpdateSaleItemCommand>())
-            .Returns(call => new SaleItem(Guid.NewGuid(), 2, new ProductDetails("Test", "Cat", 100m, "img")));
+            .Returns(call => new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 2, new ProductDetails("Test", "Cat", 100m, "img")));
         _mapper.Map<UpdateSaleResult>(sale).Returns(new UpdateSaleResult { Id = sale.Id });
 
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -77,7 +77,7 @@ public class UpdateSaleHandlerTests
         _saleRepository.UpdateAsync(sale, Arg.Any<CancellationToken>()).Returns(sale);
 
         _mapper.Map<SaleItem>(Arg.Any<UpdateSaleItemCommand>())
-            .Returns(new SaleItem(Guid.NewGuid(), 2, new ProductDetails("Test", "Cat", 100m, "img")));
+            .Returns(new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 2, new ProductDetails("Test", "Cat", 100m, "img")));
         _mapper.Map<UpdateSaleResult>(sale).Returns(new UpdateSaleResult { Id = sale.Id });
 
         await _handler.Handle(command, CancellationToken.None);
@@ -98,7 +98,7 @@ public class UpdateSaleHandlerTests
             .Throws(new InvalidOperationException("Failed to update sale"));
 
         _mapper.Map<SaleItem>(Arg.Any<UpdateSaleItemCommand>())
-            .Returns(new SaleItem(Guid.NewGuid(), 2, new ProductDetails("Test", "Cat", 100m, "img")));
+            .Returns(new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 2, new ProductDetails("Test", "Cat", 100m, "img")));
 
         // Act
         var act = async () => await _handler.Handle(command, CancellationToken.None);
@@ -119,7 +119,7 @@ public class UpdateSaleHandlerTests
         _saleRepository.UpdateAsync(sale, Arg.Any<CancellationToken>()).Returns(sale);
 
         _mapper.Map<SaleItem>(Arg.Any<UpdateSaleItemCommand>())
-            .Returns(new SaleItem(Guid.NewGuid(), 2, new ProductDetails("Test", "Cat", 100m, "img")));
+            .Returns(new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 2, new ProductDetails("Test", "Cat", 100m, "img")));
 
         _mapper.Map<UpdateSaleResult>(sale).Returns(new UpdateSaleResult { Id = sale.Id });
 

--- a/tests/Ambev.DeveloperEvaluation.Unit/Domain/Entities/SaleTest/SaleItemTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Domain/Entities/SaleTest/SaleItemTests.cs
@@ -23,18 +23,23 @@ public class SaleItemUpdateTests
     {
         // Arrange
         var initialProduct = FakeProductDetails(100);
-        var updatedProduct = FakeProductDetails(150);
-        var item = new SaleItem(Guid.NewGuid(), 5, initialProduct);
+        var updatedProduct = FakeProductDetails(150); // Novo preço
+        var item = new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 5, initialProduct);
         var newQuantity = 10;
 
         // Act
         item.Update(item.ProductId, newQuantity, updatedProduct);
 
         // Assert
+        var expectedDiscount = 0.20m; // Com 10 unidades, o desconto deve ser 20%
+        var expectedUnitPrice = updatedProduct.Price * (1 - expectedDiscount); // 150 * 0.8 = 120
+        var expectedTotal = newQuantity * expectedUnitPrice; // 10 * 120 = 1200
+
         item.Quantity.Should().Be(newQuantity);
-        item.ProductDetails.Should().Be(updatedProduct);
-        item.UnitPrice.Should().Be(updatedProduct.Price * (1 - item.Discount));
-        item.TotalAmount.Should().Be(item.Quantity * item.UnitPrice);
+        item.Discount.Should().Be(expectedDiscount);
+        item.UnitPrice.Should().Be(expectedUnitPrice);
+        item.TotalAmount.Should().Be(expectedTotal);
+        item.ProductDetails.Should().BeEquivalentTo(updatedProduct);
         item.UpdatedAt.Should().NotBeNull();
     }
 
@@ -43,7 +48,7 @@ public class SaleItemUpdateTests
     {
         // Arrange
         var product = FakeProductDetails(100);
-        var item = new SaleItem(Guid.NewGuid(), 10, product);
+        var item = new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 10, product);
 
         // Act
         Action act = () => item.Update(item.ProductId, 21, product);
@@ -58,7 +63,7 @@ public class SaleItemUpdateTests
     {
         // Arrange
         var product = FakeProductDetails(100);
-        var item = new SaleItem(Guid.NewGuid(), 10, product);
+        var item = new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 10, product);
 
         // Act
         Action act = () => item.Update(item.ProductId, 0, product);
@@ -73,7 +78,7 @@ public class SaleItemUpdateTests
     {
         // Arrange
         var product = FakeProductDetails(100);
-        var item = new SaleItem(Guid.NewGuid(), 5, product);
+        var item = new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 5, product);
 
         // Act
         Action act = () => item.Update(item.ProductId, 5, null!);
@@ -88,7 +93,7 @@ public class SaleItemUpdateTests
     {
         // Arrange
         var product = FakeProductDetails(200);
-        var item = new SaleItem(Guid.NewGuid(), 3, product); // Sem desconto
+        var item = new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 3, product); // Sem desconto
 
         // Act
         item.Update(item.ProductId, 10, product); // Desconto de 20%

--- a/tests/Ambev.DeveloperEvaluation.Unit/Domain/Entities/SaleTest/SaleTests.cs
+++ b/tests/Ambev.DeveloperEvaluation.Unit/Domain/Entities/SaleTest/SaleTests.cs
@@ -13,36 +13,20 @@ public class SaleTests
 {
     private readonly Faker _faker = new();
 
-    [Fact(DisplayName = "Given valid input When creating sale Then initializes correctly")]
-    public void Constructor_ValidInput_ShouldCreateSale()
-    {
-        // Arrange
-        var items = GetValidItems();
-
-        // Act
-        var sale = new Sale(_faker.Random.Hash(), DateTime.UtcNow, Guid.NewGuid(), _faker.Name.FullName(), _faker.Company.CompanyName(), items);
-
-        // Assert
-        sale.Should().NotBeNull();
-        sale.TotalAmount.Should().BeGreaterThan(0);
-        sale.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
-        sale.Items.Should().HaveCount(1);
-    }
-
     [Theory(DisplayName = "Given invalid sale number When creating sale Then throws exception")]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
     public void Constructor_InvalidSaleNumber_ThrowsException(string saleNumber)
     {
-        var act = () => new Sale(saleNumber, DateTime.UtcNow, Guid.NewGuid(), _faker.Name.FullName(), _faker.Company.CompanyName(), GetValidItems());
+        var act = () => new Sale(saleNumber, DateTime.UtcNow, Guid.NewGuid(), _faker.Name.FullName(), _faker.Company.CompanyName());
         act.Should().Throw<ArgumentException>().WithMessage("*Sale number*");
     }
 
     [Fact(DisplayName = "Given empty customerId When creating sale Then throws exception")]
     public void Constructor_InvalidCustomerId_ThrowsException()
     {
-        var act = () => new Sale(_faker.Random.Hash(), DateTime.UtcNow, Guid.Empty, _faker.Name.FullName(), _faker.Company.CompanyName(), GetValidItems());
+        var act = () => new Sale(_faker.Random.Hash(), DateTime.UtcNow, Guid.Empty, _faker.Name.FullName(), _faker.Company.CompanyName());
         act.Should().Throw<ArgumentException>().WithMessage("*CustomerId*");
     }
 
@@ -52,15 +36,8 @@ public class SaleTests
     [InlineData(" ")]
     public void Constructor_InvalidBranch_ThrowsException(string? branch)
     {
-        var act = () => new Sale(_faker.Random.Hash(), DateTime.UtcNow, Guid.NewGuid(), _faker.Name.FullName(), branch, GetValidItems());
+        var act = () => new Sale(_faker.Random.Hash(), DateTime.UtcNow, Guid.NewGuid(), _faker.Name.FullName(), branch);
         act.Should().Throw<ArgumentException>().WithMessage("*Branch*");
-    }
-
-    [Fact(DisplayName = "Given empty item list When creating sale Then throws domain exception")]
-    public void Constructor_EmptyItemList_ThrowsDomainException()
-    {
-        var act = () => new Sale(_faker.Random.Hash(), DateTime.UtcNow, Guid.NewGuid(), _faker.Name.FullName(), _faker.Company.CompanyName(), []);
-        act.Should().Throw<Exception>().WithMessage("A sale must have at least one item.");
     }
 
     [Fact(DisplayName = "Given valid update When updating sale Then values are updated")]
@@ -75,24 +52,15 @@ public class SaleTests
         var newCustomer = _faker.Name.FullName();
         var newBranch = _faker.Company.CompanyName();
         var newCustomerId = Guid.NewGuid();
-        sale.UpdateSale(newNumber, DateTime.UtcNow.AddDays(1), newCustomerId, newCustomer, newBranch, true, updatedItems);
+        sale.UpdateSale(newNumber, DateTime.UtcNow.AddDays(1), newCustomerId, newCustomer, newBranch, true);
 
         // Assert
         sale.SaleNumber.Should().Be(newNumber);
         sale.CustomerName.Should().Be(newCustomer);
         sale.Branch.Should().Be(newBranch);
         sale.CustomerId.Should().Be(newCustomerId);
-        sale.Items.Should().HaveCount(1);
         sale.IsCancelled.Should().BeTrue();
         sale.UpdatedAt.Should().NotBeNull();
-    }
-
-    [Fact(DisplayName = "Given empty updated items When updating sale Then throws domain exception")]
-    public void UpdateSale_EmptyItems_ThrowsDomainException()
-    {
-        var sale = CreateValidSale();
-        var act = () => sale.UpdateSale("SALE002", DateTime.UtcNow, Guid.NewGuid(), _faker.Name.FullName(), _faker.Company.CompanyName(), false, []);
-        act.Should().Throw<Exception>().WithMessage("A sale must have at least one item.");
     }
 
     private Sale CreateValidSale()
@@ -102,15 +70,14 @@ public class SaleTests
             DateTime.UtcNow,
             Guid.NewGuid(),
             _faker.Name.FullName(),
-            _faker.Company.CompanyName(),
-            GetValidItems());
+            _faker.Company.CompanyName());
     }
 
     private List<SaleItem> GetValidItems()
     {
         return new List<SaleItem>
         {
-            new SaleItem(Guid.NewGuid(), 10, new ProductDetails(
+            new SaleItem(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), 10, new ProductDetails(
                 _faker.Commerce.ProductName(),
                 _faker.Commerce.Categories(1).First(),
                 _faker.Random.Decimal(100, 5000),


### PR DESCRIPTION
Este PR corrige o problema de `DbUpdateConcurrencyException` relacionado ao uso do campo `xmin` como token de concorrência otimista no PostgreSQL.  

Alterações principais:
- Corrigida a lógica de atualização de itens na entidade `Sale`.
- Implementado controle explícito de `EntityState` no repositório para refletir operações de adição, atualização e exclusão de itens.
- Ajustado o mapeamento do owned type `ProductDetails` para garantir persistência completa no EF Core.
- Testes unitarios revisados