### PR TITLE
fix: disponibiliza maneira de subir dependências local

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 8080
-EXPOSE 8081
 
 # Instala pg_isready
 RUN apt-get update && apt-get install -y postgresql-client

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Make sure the following are installed on your machine:
 ### 1. Clone the repository
 ```bash
 git clone https://github.com/aurilio/sales-api.git
-cd sales-api
+
+cd sales-api\src\Ambev.DeveloperEvaluation.WebApi
 ```
 
 ### 2. Build and run with Docker Compose
@@ -60,7 +61,6 @@ docker-compose up -d
 
 ### 3. Start the API manually (if not using Docker)
 ```bash
-cd src/Ambev.DeveloperEvaluation.WebApi
 dotnet run
 ```
 
@@ -84,7 +84,6 @@ Open your browser and navigate to:
 ```bash
 
 Swagger (API)	http://localhost:8080/swagger/index.html
-Frontend (UI)	http://localhost:4200 - already integrated with the API
 
 ```
 

--- a/src/Ambev.DeveloperEvaluation.WebApi/Program.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Program.cs
@@ -94,8 +94,8 @@ public class Program
 
             builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 
-            if (!builder.Environment.IsDevelopment())
-                builder.WebHost.UseUrls("http://0.0.0.0:8080", "https://0.0.0.0:8081");
+            if (builder.Environment.IsProduction())
+                builder.WebHost.UseUrls("http://0.0.0.0:8080");
 
             var app = builder.Build();
 

--- a/src/Ambev.DeveloperEvaluation.WebApi/appsettings.Development.json
+++ b/src/Ambev.DeveloperEvaluation.WebApi/appsettings.Development.json
@@ -1,12 +1,20 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True;Include Error Detail=true"
+  },
+  "Jwt": {
+    "SecretKey": "YourSuperSecretKeyForJwtTokenGenerationThatShouldBeAtLeast32BytesLong"
+  },
   "Logging": {
     "LogLevel": {
-      "Default": "Debug", // Loga tudo abaixo de Debug (Trace, Debug, Information, Warning, Error, Critical)
-      "Microsoft": "Warning", // Menos verboso para logs da Microsoft
-      "Microsoft.AspNetCore": "Information", // Um pouco mais de detalhe do ASP.NET Core
-      "Ambev.DeveloperEvaluation": "Debug" // Loga logs detalhados do seu próprio código
+      "Default": "Debug",
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Information",
+      "Ambev.DeveloperEvaluation": "Debug",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.Extensions.DependencyInjection": "Debug"
     },
-    "Console": { // Adiciona um provider de console se não estiver implícito
+    "Console": {
       "LogLevel": {
         "Default": "Debug",
         "Microsoft": "Warning",
@@ -14,5 +22,6 @@
         "Ambev.DeveloperEvaluation": "Debug"
       }
     }
-  }
+  },
+  "AllowedHosts": "*"
 }

--- a/src/Ambev.DeveloperEvaluation.WebApi/appsettings.json
+++ b/src/Ambev.DeveloperEvaluation.WebApi/appsettings.json
@@ -1,22 +1,20 @@
 {
   "ConnectionStrings": {
     "DefaultConnection": "Server=ambev.developerevaluation.database;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True"
-    //"DefaultConnection": "Server=localhost;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True",
-    //"DefaultConnection": "Server=localhost;Port=5432;Database=developer_evaluation;User Id=developer;Password=ev@luAt10n;TrustServerCertificate=True;Include Error Detail=true"
   },
   "Jwt": {
     "SecretKey": "YourSuperSecretKeyForJwtTokenGenerationThatShouldBeAtLeast32BytesLong"
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Debug", // Loga tudo abaixo de Debug (Trace, Debug, Information, Warning, Error, Critical)
-      "Microsoft": "Warning", // Menos verboso para logs da Microsoft
-      "Microsoft.AspNetCore": "Information", // Um pouco mais de detalhe do ASP.NET Core
-      "Ambev.DeveloperEvaluation": "Debug", // Loga logs detalhados do seu próprio código 
+      "Default": "Debug",
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Information",
+      "Ambev.DeveloperEvaluation": "Debug",
       "Microsoft.Hosting.Lifetime": "Information",
-      "Microsoft.Extensions.DependencyInjection": "Debug" // Adicione ou ajuste esta linha
+      "Microsoft.Extensions.DependencyInjection": "Debug"
     },
-    "Console": { // Adiciona um provider de console se não estiver implícito
+    "Console": {
       "LogLevel": {
         "Default": "Debug",
         "Microsoft": "Warning",

--- a/src/Ambev.DeveloperEvaluation.WebApi/docker-compose.yml
+++ b/src/Ambev.DeveloperEvaluation.WebApi/docker-compose.yml
@@ -1,29 +1,4 @@
 services:
-  ambev.developerevaluation.webapi:
-    container_name: ambev_developer_evaluation_webapi
-    image: ${DOCKER_REGISTRY-}ambevdeveloperevaluationwebapi
-    build:
-      context: .
-      dockerfile: Dockerfile
-    entrypoint: ["./wait-for-postgres.sh", "ambev.developerevaluation.database", "dotnet", "Ambev.DeveloperEvaluation.WebApi.dll"]
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Production
-      - ASPNETCORE_URLS=http://0.0.0.0:8080
-      - ASPNETCORE_HTTP_PORTS=8080
-      - POSTGRES_USER=developer
-      - POSTGRES_PASSWORD=ev@luAt10n
-    ports:
-      - "8080:8080"
-    depends_on:
-      ambev.developerevaluation.database:
-        condition: service_healthy
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-
   ambev.developerevaluation.database:
     container_name: ambev_developer_evaluation_database
     image: postgres:13


### PR DESCRIPTION
Esse PR faz um ajuste para deixar o arquivo docker-compose.yml configurado para subir as dependências do projeto. Removendo o projeto do front-end que esta em outro diretório.
E ajustando appsettings para fazer distinção entre ambiente Dev e Produção.